### PR TITLE
Match the env file to docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Need to setup
 AKAUNTING_VERSION=3.0.17
-MARIADB_ROOT_PASSWORD=root
-MARIADB_DATABASE=akaunting
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=akaunting
 ADM_EMAIL=admin@test.domain
 ADM_PASSWD=admin
 


### PR DESCRIPTION
There is a mismatch of the env variables used across the docker-compose file and the .env example file.