### PR TITLE
fix: make npm available in php runtime and align entrypoint shell

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -37,16 +37,15 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-# Install NVM
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
-    && export NVM_DIR="/root/.nvm" \
-    && . "$NVM_DIR/nvm.sh" \
-    && nvm install 20 \
-    && nvm alias default 20
+# Install Node.js and npm from official Node image
+COPY --from=node:20-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node:20-bookworm-slim /usr/local/bin/node /usr/local/bin/node
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 COPY config/php.ini /usr/local/etc/php/conf.d/
 
 WORKDIR /var/www/html
 COPY wait-for-db.php /usr/local/bin/wait-for-db.php
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["sh", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["bash", "/usr/local/bin/entrypoint.sh"]

--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -9,7 +9,7 @@ if [ ! -f "vendor/autoload.php" ]; then
     git clone --progress -b "${AKAUNTING_VERSION}" --single-branch --depth 1 https://github.com/akaunting/akaunting /tmp/akaunting
     rsync -r /tmp/akaunting/ .
     rm -rf /tmp/akaunting
-    if [ $APP_ENV == "production" ]; then
+    if [ "${APP_ENV}" = "production" ]; then
         composer install --no-dev --no-scripts
     else
         composer install --no-scripts
@@ -19,11 +19,11 @@ if [ ! -f "vendor/autoload.php" ]; then
     composer dump-autoload
     php artisan install --no-interaction --db-host="${DB_HOST}" --db-port="${DB_PORT}" --db-name="${DB_DATABASE}" --db-username="${DB_USERNAME}" --db-password="${DB_PASSWORD}" --db-prefix="${DB_PREFIX}" --admin-email="${ADM_EMAIL}" --admin-password="${ADM_PASSWD}"
     npm ci
-    if [ $APP_ENV == "production" ]; then
+    if [ "${APP_ENV}" = "production" ]; then
         npm run production
     else
         npm run dev
     fi
     chown -R www-data:www-data .
 fi
-php-fpm
+exec php-fpm


### PR DESCRIPTION
## Summary
This PR fixes the issue where `npm` was not available during container bootstrap in the PHP service.

## Changes
- Replace NVM-based Node setup in PHP image with Node/NPM from official `node:20-bookworm-slim` image
- Create explicit symlinks for `npm` and `npx`
- Run entrypoint with `bash` instead of `sh`
- Make environment checks in entrypoint shell-safe and use `exec php-fpm`

## Validation
- `docker compose build akaunting.php`
- `docker compose exec -u www-data akaunting.php node --version`

Closes #8